### PR TITLE
Less greedy regex

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -28,7 +28,7 @@ class syntax_plugin_ireadit extends DokuWiki_Syntax_Plugin
 
     function connectTo($mode)
     {
-        $this->Lexer->addSpecialPattern('~~IREADIT.*~~', $mode, 'plugin_ireadit');
+        $this->Lexer->addSpecialPattern('~~IREADIT.*?~~', $mode, 'plugin_ireadit');
     }
 
     function handle($match, $state, $pos, Doku_Handler $handler)


### PR DESCRIPTION
Make sure that the syntax matches only what it should. In some cases it would "swallow" content beyond the actual "~~" boundary and break the preview.