### PR TITLE
list: Use <li> instead of <div> in <ul>

### DIFF
--- a/syntax/list.php
+++ b/syntax/list.php
@@ -152,7 +152,7 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
                 $link .= noNSorNS($page);
             }
             $link .= '</a>';
-            $renderer->doc .= '<div class="li">' . $link . '</div>';
+            $renderer->doc .= '<li class="li">' . $link . '</li>';
         }
         $renderer->doc .= '</ul>';
     }


### PR DESCRIPTION
<div> in <ul> is invalid HTML, and rendering is nicer with <li>