### PR TITLE
List of outdated pages

### DIFF
--- a/syntax/list.php
+++ b/syntax/list.php
@@ -40,13 +40,21 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
             $key = trim($pair[0]);
             $value = trim($pair[1]);
             if ($key == 'state') {
-                $states = ['read', 'not read', 'outdated', 'all'];
-                $value = strtolower($value);
-                $value = array_map('trim', explode(',', $value));
-                foreach ($value as $item) {
-                    if (!in_array($item, $states)) {
-                        msg('ireadit plugin: unknown state "'.$item.'" should be: ' .
-                            implode(', ', $states), -1);
+                $statemap = [
+                    'read' => ['read'],
+                    'outdated' => ['outdated'],
+                    'unread' => ['unread'],
+                    'not read' => ['outdated', 'unread'],
+                    'all' => ['read', 'outdated', 'unread'],
+                ];
+                $states = array_map('trim', explode(',', strtolower($value)));
+                $value = [];
+                foreach ($states as $state) {
+                    if (isset($statemap[$state])) {
+                        $value += $statemap[$state];
+                    } else {
+                        msg('ireadit plugin: unknown state "'.$state.'" should be: ' .
+                            implode(', ', array_kes($statemap)), -1);
                         return false;
                     }
                 }
@@ -145,13 +153,13 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
         while ($row = $sqlite->res_fetch_assoc($res)) {
             $page = $row['page'];
             if (!isset($row['read_rev'])) {
-                $state = 'not read';
+                $state = 'unread';
             } elseif ($row['read_rev'] == $row['current_rev']) {
                 $state = 'read';
             } else {
                 $state = 'outdated';
             }
-            if (!in_array($state, $params['state']) && !in_array('all', $params['state'])) {
+            if (!in_array($state, $params['state'])) {
                 continue;
             }
 

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -42,10 +42,13 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
             if ($key == 'state') {
                 $states = ['read', 'not read', 'outdated', 'all'];
                 $value = strtolower($value);
-                if (!in_array($value, $states)) {
-                    msg('ireadit plugin: unknown state "'.$value.'" should be: ' .
-                        implode(', ', $states), -1);
-                    return false;
+                $value = array_map('trim', explode(',', $value));
+                foreach ($value as $item) {
+                    if (!in_array($item, $states)) {
+                        msg('ireadit plugin: unknown state "'.$item.'" should be: ' .
+                            implode(', ', $states), -1);
+                        return false;
+                    }
                 }
             }
             $params[$key] = $value;
@@ -148,8 +151,9 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
             } else {
                 $state = 'outdated';
             }
-            if ($params['state'] != 'all' && $params['state'] != $state)
+            if (!in_array($state, $params['state']) && !in_array('all', $params['state'])) {
                 continue;
+            }
 
             $url = wl($page);
             if (isset($row['read_rev'])) {

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -151,7 +151,11 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
             if ($params['state'] != 'all' && $params['state'] != $state)
                 continue;
 
-            $link = '<a class="wikilink1" href="' . wl($page) . '">';
+            $url = wl($page);
+            if (isset($row['read_rev'])) {
+                $url .= '?rev=' . $row['read_rev'];
+            }
+            $link = '<a class="wikilink1" href="' . $url . '">';
             if (useHeading('content')) {
                 $heading = p_get_first_heading($page);
                 if (!blank($heading)) {

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -39,11 +39,11 @@ class syntax_plugin_ireadit_list extends DokuWiki_Syntax_Plugin {
             }
             $key = trim($pair[0]);
             $value = trim($pair[1]);
-            if ($key == 'states') {
+            if ($key == 'state') {
                 $states = ['read', 'not read', 'all'];
                 $value = strtolower($value);
-                if (!in_array($state, $states)) {
-                    msg('ireadit plugin: unknown state "'.$state.'" should be: ' .
+                if (!in_array($value, $states)) {
+                    msg('ireadit plugin: unknown state "'.$value.'" should be: ' .
                         implode(', ', $states), -1);
                     return false;
                 }


### PR DESCRIPTION
This PR introduces a new state "outdated" that can be used in the list of pages a user has read, meaning that the user has read an old version of the page but not the current one. It doesn't change the semantics of the existing states "all", "read" and "not read" (only the technical implementation thereof), but also introduces the new state "unread" to mean "neither read the current nor an outdated version of the page". Multiple states can be specified separated by comma, and the total state map looks like this:

```
                    'read' => ['read'],
                    'outdated' => ['outdated'],
                    'unread' => ['unread'],
                    'not read' => ['outdated', 'unread'],
                    'all' => ['read', 'outdated', 'unread'],
```

Includes PR #17, as this also touches the argument validation.

## Outlook

I plan on integrating this with the approve plugin as well (when it is also installed and the page is under approval control) by modifying the meaning of "read" to mean "read at least the latest approved version" and the meaning of "outdated" to mean "read an older version than the latest approved one".

I further plan to implement a table (as an alternative to the list) with an overview over the page name, the revision read by the user, the latest revision and the latest approved revision, color coding the state of each page.

Both of these will be separate PRs and will depend on this one.